### PR TITLE
V 0.3.1

### DIFF
--- a/includes/off-canvas-sidebars-frontend.class.php
+++ b/includes/off-canvas-sidebars-frontend.class.php
@@ -10,8 +10,8 @@
 
 ! defined( 'ABSPATH' ) and die( 'You shall not pass!' );
 
-final class OCS_Off_Canvas_Sidebars_Frontend {
-
+final class OCS_Off_Canvas_Sidebars_Frontend
+{
 	/**
 	 * The single instance of the class.
 	 *
@@ -106,12 +106,10 @@ final class OCS_Off_Canvas_Sidebars_Frontend {
 			if ( is_array( $value ) ) {
 				$value = implode( ' ', $value );
 			}
-
 			$atts[ $name ] = $name . '="' . $value . '"';
 		}
-		$atts = implode( ' ', $atts );
 
-		echo '<div id="' . $this->general_settings['css_prefix'] . '-site" canvas="container" ' . $atts . '>';
+		echo '<div id="' . $this->general_settings['css_prefix'] . '-site" canvas="container" ' . implode( ' ', $atts ) . '>';
 
 		// Add content before other content in the site container
 		do_action( 'ocs_container_inner_before' );
@@ -368,7 +366,7 @@ final class OCS_Off_Canvas_Sidebars_Frontend {
 	}
 
 	/**
-	 * Add nessesary inline scripts
+	 * Add necessary inline scripts
 	 *
 	 * @since   0.1
 	 * @return  void
@@ -391,6 +389,7 @@ final class OCS_Off_Canvas_Sidebars_Frontend {
 	 */
 	function add_inline_styles() {
 		if ( ! is_admin() ) {
+			$prefix = $this->general_settings['css_prefix'];
 			?>
 <style type="text/css">
 <?php
@@ -398,20 +397,22 @@ if ( $this->general_settings['background_color_type'] != '' ) {
 	$bgcolor = '';
 	if ( $this->general_settings['background_color_type'] == 'transparent' ) {
 		$bgcolor = 'transparent';
-	} else if ( $this->general_settings['background_color_type'] == 'color' && $this->general_settings['background_color'] != '' ) {
+	}
+	elseif ( $this->general_settings['background_color_type'] == 'color' && $this->general_settings['background_color'] != '' ) {
 		$bgcolor = $this->general_settings['background_color'];
 	}
 ?>
-	#<?php echo $this->general_settings['css_prefix']; ?>-site {background-color: <?php echo $bgcolor; ?>;}
-<?php } ?>
+	#<?php echo $prefix; ?>-site {background-color: <?php echo $bgcolor; ?>;}
 <?php
+} // endif
 foreach ( $this->general_settings['sidebars'] as $sidebar_id => $sidebar_data ) {
 	if ( true === (bool) $sidebar_data['enable'] ) {
 		$prop = array();
 		if ( ! empty( $sidebar_data['background_color_type'] ) ) {
 			if ( $sidebar_data['background_color_type'] == 'transparent' ) {
 				$prop[] = 'background-color: transparent;';
-			} else if ( $sidebar_data['background_color_type'] == 'color' && $sidebar_data['background_color'] != '' ) {
+			}
+			elseif ( $sidebar_data['background_color_type'] == 'color' && $sidebar_data['background_color'] != '' ) {
 				$prop[] = 'background-color: ' . $sidebar_data['background_color'] . ';';
 			}
 		}
@@ -432,15 +433,17 @@ foreach ( $this->general_settings['sidebars'] as $sidebar_id => $sidebar_data ) 
 			$prop[] = 'transition-duration: ' . $speed . 'ms;';
 		}
 		if ( ! empty( $sidebar_data['padding'] ) ) {
-			// http://www.w3schools.com/cssref/css3_pr_transition-duration.asp
-			$padding = (int) $sidebar_data['padding'];
-			$prop[] = 'padding: ' . $padding . 'px;';
+			$prop[] = 'padding: ' . (int) $sidebar_data['padding'] . 'px;';
 		}
 
 		if ( ! empty( $prop ) ) {
 ?>
 	.ocs-slidebar.ocs-<?php echo $sidebar_id; ?> {<?php echo implode( ' ', $prop ); ?>}
-<?php }}} //endif //endif endforeach ?>
+<?php
+		} //endif
+	} // endif
+} //endforeach
+?>
 </style>
 			<?php
 		}

--- a/includes/off-canvas-sidebars-frontend.class.php
+++ b/includes/off-canvas-sidebars-frontend.class.php
@@ -444,6 +444,7 @@ foreach ( $this->general_settings['sidebars'] as $sidebar_id => $sidebar_data ) 
 	} // endif
 } //endforeach
 ?>
+	.<?php echo $prefix; ?>-button {cursor: pointer;}
 </style>
 			<?php
 		}

--- a/includes/off-canvas-sidebars-frontend.class.php
+++ b/includes/off-canvas-sidebars-frontend.class.php
@@ -5,7 +5,7 @@
  * Front-end
  * @author Jory Hogeveen <info@keraweb.nl>
  * @package off-canvas-sidebars
- * @version 0.3
+ * @version 0.3.1
  */
 
 ! defined( 'ABSPATH' ) and die( 'You shall not pass!' );

--- a/includes/off-canvas-sidebars-frontend.class.php
+++ b/includes/off-canvas-sidebars-frontend.class.php
@@ -436,9 +436,11 @@ foreach ( $this->general_settings['sidebars'] as $sidebar_id => $sidebar_data ) 
 			$padding = (int) $sidebar_data['padding'];
 			$prop[] = 'padding: ' . $padding . 'px;';
 		}
+
+		if ( ! empty( $prop ) ) {
 ?>
 	.ocs-slidebar.ocs-<?php echo $sidebar_id; ?> {<?php echo implode( ' ', $prop ); ?>}
-<?php }} //endif endforeach ?>
+<?php }}} //endif //endif endforeach ?>
 </style>
 			<?php
 		}

--- a/includes/off-canvas-sidebars-menu-meta-box.class.php
+++ b/includes/off-canvas-sidebars-menu-meta-box.class.php
@@ -12,8 +12,8 @@
 
 ! defined( 'ABSPATH' ) and die( 'You shall not pass!' );
 
-final class OCS_Off_Canvas_Sidebars_Menu_Meta_box {
-
+final class OCS_Off_Canvas_Sidebars_Menu_Meta_box
+{
 	/**
 	 * The single instance of the class.
 	 *

--- a/includes/off-canvas-sidebars-settings.class.php
+++ b/includes/off-canvas-sidebars-settings.class.php
@@ -116,7 +116,7 @@ final class OCS_Off_Canvas_Sidebars_Settings {
 		foreach ($this->general_settings['sidebars'] as $sidebar => $sidebar_data) {
 			add_settings_section(
 				'section_sidebar_'.$sidebar,
-				__( 'Off-Canvas Sidebar - <code class="js-dynamic-id">'.$this->general_settings['sidebars'][ $sidebar ]['label'] . '</code>', 'off-canvas-sidebars' ),
+				__( 'Off-Canvas Sidebar', 'off-canvas-sidebars' ) . ' - <code class="js-dynamic-id">' . $this->general_settings['sidebars'][ $sidebar ]['label'] . '</code>',
 				array( $this, 'register_general_settings' ),
 				$this->sidebars_tab
 			);

--- a/includes/off-canvas-sidebars-settings.class.php
+++ b/includes/off-canvas-sidebars-settings.class.php
@@ -10,8 +10,8 @@
 
 ! defined( 'ABSPATH' ) and die( 'You shall not pass!' );
 
-final class OCS_Off_Canvas_Sidebars_Settings {
-
+final class OCS_Off_Canvas_Sidebars_Settings
+{
 	/**
 	 * The single instance of the class.
 	 *
@@ -932,7 +932,7 @@ final class OCS_Off_Canvas_Sidebars_Settings {
 	/**
 	 * Updates the existing widgets when a sidebar ID changes
 	 *
-	 * @since 0.3
+	 * @since  0.3
 	 *
 	 * @param  string  $oldId
 	 * @param  string  $newId
@@ -978,9 +978,9 @@ final class OCS_Off_Canvas_Sidebars_Settings {
 	/**
 	 * Validates numeric values, used by validate_input
 	 *
-	 * @since 0.2.2
+	 * @since  0.2.2
 	 *
-	 * @param mixed $value
+	 * @param  mixed $value
 	 * @return string $value
 	 */
 	function validate_numeric( $value ) {
@@ -990,9 +990,9 @@ final class OCS_Off_Canvas_Sidebars_Settings {
 	/**
 	 * Remove whitespace
 	 *
-	 * @since 0.3
+	 * @since  0.3
 	 *
-	 * @param mixed $value
+	 * @param  mixed $value
 	 * @return string $value
 	 */
 	function remove_whitespace( $value ) {
@@ -1085,9 +1085,10 @@ final class OCS_Off_Canvas_Sidebars_Settings {
 	 * This function is similar to the function in the Settings API, only the output HTML is changed.
 	 * Print out the settings fields for a particular settings section
 	 *
-	 * @global $wp_settings_fields  array of settings fields and their pages/sections
-	 *
 	 * @since  0.1
+	 *
+	 * @global $wp_settings_sections  array of settings sections
+	 * @global $wp_settings_fields    array of settings fields and their pages/sections
 	 *
 	 * @param  string  $page     Slug title of the admin page who's settings fields you want to show.
 	 * @param  string  $section  Slug title of the settings section who's fields you want to show.
@@ -1151,17 +1152,16 @@ final class OCS_Off_Canvas_Sidebars_Settings {
 	}
 
 	function importexport_fields() {
-		?>
-	<h3><?php _e( 'Import/Export Settings', 'off-canvas-sidebars' ); ?></h3>
+	?>
+		<h3><?php _e( 'Import/Export Settings', 'off-canvas-sidebars' ); ?></h3>
 
-	<p><a class="submit button" href="?<?php echo $this->plugin_key ?>-export"><?php esc_attr_e( 'Export Settings', 'off-canvas-sidebars' ); ?></a></p>
+		<p><a class="submit button" href="?<?php echo $this->plugin_key ?>-export"><?php esc_attr_e( 'Export Settings', 'off-canvas-sidebars' ); ?></a></p>
 
-	<p>
-		<input type="hidden" name="<?php echo $this->plugin_key ?>-import" id="<?php echo $this->plugin_key ?>-import" value="true" />
-		<?php submit_button( esc_attr__( 'Import Settings', 'off-canvas-sidebars' ), 'button', $this->plugin_key . '-submit', false ); ?>
-		<input type="file" name="<?php echo $this->plugin_key ?>-import-file" id="<?php echo $this->plugin_key ?>-import-file" />
-	</p>
-
+		<p>
+			<input type="hidden" name="<?php echo $this->plugin_key ?>-import" id="<?php echo $this->plugin_key ?>-import" value="true" />
+			<?php submit_button( esc_attr__( 'Import Settings', 'off-canvas-sidebars' ), 'button', $this->plugin_key . '-submit', false ); ?>
+			<input type="file" name="<?php echo $this->plugin_key ?>-import-file" id="<?php echo $this->plugin_key ?>-import-file" />
+		</p>
 	<?php
 	}
 
@@ -1211,9 +1211,9 @@ final class OCS_Off_Canvas_Sidebars_Settings {
 		// import settings
 		if ( isset( $_POST[ $this->plugin_key . '-import'] ) ) {
 
-			if ( $_FILES[ $this->plugin_key . '-import-file']['tmp_name'] ) {
+			if ( $_FILES[ $this->plugin_key . '-import-file' ]['tmp_name'] ) {
 
-				$import = explode( "\n", file_get_contents( $_FILES[ $this->plugin_key . '-import-file']['tmp_name'] ) );
+				$import = explode( "\n", file_get_contents( $_FILES[ $this->plugin_key . '-import-file' ]['tmp_name'] ) );
 				if ( array_shift( $import ) == "[START=OCS SETTINGS]" && array_pop( $import ) == "[STOP=OCS SETTINGS]" ) {
 
 					$settings = array();

--- a/includes/off-canvas-sidebars-settings.class.php
+++ b/includes/off-canvas-sidebars-settings.class.php
@@ -522,10 +522,10 @@ final class OCS_Off_Canvas_Sidebars_Settings {
 		$prefixName = esc_attr( $this->general_key ).'[sidebars]';
 		$prefixValue = $this->general_settings['sidebars'];
 		$prefixId = $this->general_key.'_sidebars';
-		$prefixClasses = array( $prefixId );
+		//$prefixClasses = array( $prefixId );
 		?><fieldset><?php
 		foreach ($prefixValue as $sidebar => $sidebar_data) {
-			$classes = $this->get_option_classes( $prefixClasses, 'enable' );
+			//$classes = $this->get_option_classes( $prefixClasses, 'enable' );
 		?>
 			<label><input type="checkbox" name="<?php echo $prefixName.'['.$sidebar.'][enable]'; ?>" id="<?php echo $prefixId.'_enable_'.$sidebar; ?>" value="1" <?php checked( $prefixValue[$sidebar]['enable'], 1 ); ?> /> <?php echo $this->general_settings['sidebars'][ $sidebar ]['label']; ?></label><br />
 		<?php
@@ -712,7 +712,7 @@ final class OCS_Off_Canvas_Sidebars_Settings {
 			<label><input type="radio" name="<?php echo $prefixName.'['.$args['name'].'_type]'; ?>" class="<?php echo $classes; ?>" id="<?php echo $prefixId.'_background_color_type_transparent'; ?>" value="transparent" <?php checked( $prefixValue[$args['name'].'_type'], 'transparent' ); ?> /> <?php _e( 'Transparent', 'off-canvas-sidebars' ); ?></label><br />
 			<label><input type="radio" name="<?php echo $prefixName.'['.$args['name'].'_type]'; ?>" class="<?php echo $classes; ?>" id="<?php echo $prefixId.'_background_color_type_color'; ?>" value="color" <?php checked( $prefixValue[$args['name'].'_type'], 'color' ); ?> /> <?php _e( 'Color', 'off-canvas-sidebars' ); ?></label><br />
 			<div class="<?php echo $prefixId.'_'.$args['name'].'_wrapper'; ?>">
-			<input type="text" class="color-picker <?php echo $this->get_option_classes( $prefixClasses, $args['name'] ) ?>" id="<?php echo $prefixId.'_'.$args['name']; ?>" name="<?php echo $prefixName.'['.$args['name'].']'; ?>" value="<?php echo $prefixValue[$args['name']] ?>" />
+				<input type="text" class="color-picker <?php echo $this->get_option_classes( $prefixClasses, $args['name'] ) ?>" id="<?php echo $prefixId.'_'.$args['name']; ?>" name="<?php echo $prefixName.'['.$args['name'].']'; ?>" value="<?php echo $prefixValue[$args['name']] ?>" />
 			</div>
 			<?php if ( isset( $args['description'] ) ) { ?>
 			<p class="description"><?php echo $args['description'] ?></p>

--- a/includes/off-canvas-sidebars-settings.class.php
+++ b/includes/off-canvas-sidebars-settings.class.php
@@ -5,7 +5,7 @@
  * Settings
  * @author Jory Hogeveen <info@keraweb.nl>
  * @package off-canvas-sidebars
- * @version 0.3
+ * @version 0.3.1
  */
 
 ! defined( 'ABSPATH' ) and die( 'You shall not pass!' );

--- a/includes/off-canvas-sidebars-settings.class.php
+++ b/includes/off-canvas-sidebars-settings.class.php
@@ -81,6 +81,20 @@ final class OCS_Off_Canvas_Sidebars_Settings {
 	}
 
 	/**
+	 * Create admin page under the appearance menu
+	 * @since  0.1
+	 */
+	function add_admin_menus() {
+		add_theme_page(
+			esc_attr__( 'Off-Canvas Sidebars', 'off-canvas-sidebars' ),
+			esc_attr__( 'Off-Canvas Sidebars', 'off-canvas-sidebars' ),
+			apply_filters( 'ocs_settings_capability', 'edit_theme_options' ),
+			$this->plugin_key,
+			array( $this, 'plugin_options_page' )
+		);
+	}
+
+	/**
 	 * Register our settings
 	 * @since 0.1
 	 */
@@ -983,14 +997,6 @@ final class OCS_Off_Canvas_Sidebars_Settings {
 	 */
 	function remove_whitespace( $value ) {
 		return ( ! empty( $value ) ) ? str_replace( array( ' ' ), '', (string) $value ) : '';
-	}
-
-	/**
-	 * Create admin menu page
-	 * @since  0.1
-	 */
-	function add_admin_menus() {
-		add_submenu_page( 'themes.php', esc_attr__( 'Off-Canvas Sidebars', 'off-canvas-sidebars' ), esc_attr__( 'Off-Canvas Sidebars', 'off-canvas-sidebars' ), 'edit_theme_options', $this->plugin_key, array( $this, 'plugin_options_page' ) );
 	}
 
 	/*

--- a/includes/off-canvas-sidebars-settings.class.php
+++ b/includes/off-canvas-sidebars-settings.class.php
@@ -113,7 +113,7 @@ final class OCS_Off_Canvas_Sidebars_Settings
 		);
 
 		// Register sidebar settings
-		foreach ($this->general_settings['sidebars'] as $sidebar => $sidebar_data) {
+		foreach ( $this->general_settings['sidebars'] as $sidebar => $sidebar_data ) {
 			add_settings_section(
 				'section_sidebar_'.$sidebar,
 				__( 'Off-Canvas Sidebar', 'off-canvas-sidebars' ) . ' - <code class="js-dynamic-id">' . $this->general_settings['sidebars'][ $sidebar ]['label'] . '</code>',
@@ -523,16 +523,22 @@ final class OCS_Off_Canvas_Sidebars_Settings
 		$prefixValue = $this->general_settings['sidebars'];
 		$prefixId = $this->general_key.'_sidebars';
 		//$prefixClasses = array( $prefixId );
+		if ( ! empty( $this->general_settings['sidebars'] ) ) {
 		?><fieldset><?php
-		foreach ($prefixValue as $sidebar => $sidebar_data) {
-			//$classes = $this->get_option_classes( $prefixClasses, 'enable' );
-		?>
-			<label><input type="checkbox" name="<?php echo $prefixName.'['.$sidebar.'][enable]'; ?>" id="<?php echo $prefixId.'_enable_'.$sidebar; ?>" value="1" <?php checked( $prefixValue[$sidebar]['enable'], 1 ); ?> /> <?php echo $this->general_settings['sidebars'][ $sidebar ]['label']; ?></label><br />
-		<?php
-		}
+			foreach ($prefixValue as $sidebar => $sidebar_data) {
+				//$classes = $this->get_option_classes( $prefixClasses, 'enable' );
+			?>
+				<label><input type="checkbox" name="<?php echo $prefixName.'['.$sidebar.'][enable]'; ?>" id="<?php echo $prefixId.'_enable_'.$sidebar; ?>" value="1" <?php checked( $prefixValue[$sidebar]['enable'], 1 ); ?> /> <?php echo $this->general_settings['sidebars'][ $sidebar ]['label']; ?></label><br />
+			<?php
+			}
 		?>
 		<input type="hidden" name="<?php echo $prefixName.'[ocs_update]'; ?>" value="1" />
-		</fieldset><?php
+		</fieldset>
+		<?php
+		} else {
+			echo '<a href="?page=' . esc_attr( $this->plugin_key ) . '&tab=' . esc_attr( $this->sidebars_tab ) . '">'
+			     . __( 'Click here to add off-canvas sidebars', 'off-canvas-sidebars' ) . '</a>';
+		}
 	}
 
 	function sidebar_location( $args ) {

--- a/includes/off-canvas-sidebars-settings.class.php
+++ b/includes/off-canvas-sidebars-settings.class.php
@@ -30,6 +30,7 @@ final class OCS_Off_Canvas_Sidebars_Settings {
 	private $general_labels = array();
 
 	/**
+	 * @since  0.1
 	 * @since  0.3  private constructor
 	 * @access private
 	 */
@@ -44,6 +45,7 @@ final class OCS_Off_Canvas_Sidebars_Settings {
 
 	/**
 	 * Get plugin defaults
+	 * @since  0.1
 	 */
 	function load_plugin_data() {
 		$off_canvas_sidebars = Off_Canvas_Sidebars();
@@ -52,6 +54,11 @@ final class OCS_Off_Canvas_Sidebars_Settings {
 		$this->general_key = $off_canvas_sidebars->get_general_key();
 	}
 
+	/**
+	 * Enqueue our styles and scripts only when it's our page
+	 * @since  0.1
+	 * @param  $hook
+	 */
 	function enqueue_styles_scripts( $hook ) {
 		if ( $hook != 'appearance_page_' . $this->plugin_key ) {
 			return;
@@ -73,6 +80,10 @@ final class OCS_Off_Canvas_Sidebars_Settings {
 
 	}
 
+	/**
+	 * Register our settings
+	 * @since 0.1
+	 */
 	function register_settings() {
 		$this->plugin_tabs[ $this->settings_tab ] = esc_attr__( 'Settings', 'off-canvas-sidebars' );
 		$this->plugin_tabs[ $this->sidebars_tab ] = esc_attr__( 'Sidebars', 'off-canvas-sidebars' );
@@ -727,6 +738,13 @@ final class OCS_Off_Canvas_Sidebars_Settings {
 		return array( 'prefixName' => $prefixName, 'prefixValue' => $prefixValue, 'prefixId' => $prefixId, 'prefixClasses' => $prefixClasses );
 	}
 
+	/**
+	 * Combine classes prefixed with the field name
+	 * @since  0.2
+	 * @param  $classes
+	 * @param  $append
+	 * @return string
+	 */
 	function get_option_classes( $classes, $append ) {
 		if ( $append ) {
 			foreach ( $classes as $key => $class ) {

--- a/js/fixed-scrolltop.js
+++ b/js/fixed-scrolltop.js
@@ -30,7 +30,7 @@
 
 		function ocsScrollTopFixed() {
 			if ( curScrollTopElements.length > 0 ) {
-				var scrollTop = $(ocs_site).scrollTop();
+				var scrollTop = ocs_site.scrollTop();
 				var winHeight = $(window).height();
 				var conOffset = ocs_site.offset();
 				var conHeight = ocs_site.outerHeight();

--- a/js/fixed-scrolltop.js
+++ b/js/fixed-scrolltop.js
@@ -4,7 +4,7 @@
  * Compatibility for fixed elements with Slidebars
  * @author Jory Hogeveen <info@keraweb.nl>
  * @package off-canvas-slidebars
- * @version 0.3
+ * @version 0.3.1
  */
 ( function ( $ ) {
 
@@ -19,10 +19,10 @@
 		var ocs_site = $('#' + prefix + '-site');
 
 		if ( ocs_site.css('transform') != 'none' ) {
-			curScrollTopElements = $('#' + prefix + '-site *').filter(function(){ return $(this).css('position') === 'fixed' });
+			curScrollTopElements = $('#' + prefix + '-site *').filter( function(){ return $(this).css('position') === 'fixed'; } );
 			ocsScrollTopFixed();
-			$(window).on('scroll resize', function() {
-				var newScrollTopElements = $('#' + prefix + '-site *').filter(function(){ return $(this).css('position') === 'fixed' });
+			ocs_site.on('scroll resize', function() {
+				var newScrollTopElements = $('#' + prefix + '-site *').filter( function(){ return $(this).css('position') === 'fixed'; } );
 				curScrollTopElements = curScrollTopElements.add(newScrollTopElements);
 				ocsScrollTopFixed();
 			});
@@ -30,27 +30,33 @@
 
 		function ocsScrollTopFixed() {
 			if ( curScrollTopElements.length > 0 ) {
-				var scrollTop = $(window).scrollTop();
+				var scrollTop = $(ocs_site).scrollTop();
 				var winHeight = $(window).height();
 				var conOffset = ocs_site.offset();
 				var conHeight = ocs_site.outerHeight();
-				curScrollTopElements.each(function(){
+				curScrollTopElements.each( function() {
 					if ( $(this).css('position') == 'fixed' ) {
 						var top = $(this).css('top');
 						var bottom = $(this).css('bottom');
 						var px;
 						if ( top == 'auto' && bottom != 'auto' ) {
-							px = (scrollTop + winHeight) - (conOffset.top + conHeight);
+							px = ( scrollTop + winHeight ) - ( conOffset.top + conHeight );
 						} else {
 							px = scrollTop - conOffset.top;
 						}
-						$(this).css('-webkit-transform', 'translateY(' + px + 'px)');
-						$(this).css('-moz-transform', 'translateY(' + px + 'px)');
+						$(this).css({
+							'-webkit-transform': 'translateY(' + px + 'px)',
+							'-moz-transform': 'translateY(' + px + 'px)',
+							'transform': 'translateY(' + px + 'px)'
+						});
 					} else {
-						$(this).css({'-webkit-transform' : ''});
-						$(this).css({'-moz-transform' : ''});
+						$(this).css({
+							'-webkit-transform' : '',
+							'-moz-transform' : '',
+							'transform' : ''
+						});
 					}
-				});
+				} );
 			}
 		}
 

--- a/js/off-canvas-sidebars.js
+++ b/js/off-canvas-sidebars.js
@@ -5,9 +5,9 @@
  * @author Jory Hogeveen <info@keraweb.nl>
  * @package off-canvas-sidebars
  * @version 0.3
+ * @global ocsOffCanvasSidebars
  */
 
-/* global ocsOffCanvasSidebars */
 if ( typeof ocsOffCanvasSidebars == 'undefined' ) {
 	var ocsOffCanvasSidebars = {
 		"site_close": true,

--- a/off-canvas-sidebars.php
+++ b/off-canvas-sidebars.php
@@ -594,7 +594,11 @@ final class OCS_Off_Canvas_Sidebars
 	 * @return  void
 	 */
 	public function __clone() {
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Whoah, partner!', 'off-canvas-sidebars' ), null );
+		_doing_it_wrong(
+			__FUNCTION__,
+			get_class( $this ) . ': ' . esc_html__( 'This class does not want to be cloned', 'view-admin-as' ),
+			null
+		);
 	}
 
 	/**
@@ -605,7 +609,11 @@ final class OCS_Off_Canvas_Sidebars
 	 * @return  void
 	 */
 	public function __wakeup() {
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Whoah, partner!', 'off-canvas-sidebars' ), null );
+		_doing_it_wrong(
+			__FUNCTION__,
+			get_class( $this ) . ': ' . esc_html__( 'This class does not want to wake up', 'view-admin-as' ),
+			null
+		);
 	}
 
 	/**
@@ -618,7 +626,11 @@ final class OCS_Off_Canvas_Sidebars
 	 * @return  null
 	 */
 	public function __call( $method = '', $args = array() ) {
-		_doing_it_wrong( get_class( $this ) . "::{$method}", esc_html__( 'Method does not exist.', 'off-canvas-sidebars' ), null );
+		_doing_it_wrong(
+			get_class( $this ) . "::{$method}",
+			esc_html__( 'Method does not exist.', 'off-canvas-sidebars' ),
+			null
+		);
 		unset( $method, $args );
 		return null;
 	}

--- a/off-canvas-sidebars.php
+++ b/off-canvas-sidebars.php
@@ -3,7 +3,7 @@
  * Plugin Name: Off-Canvas Sidebars
  * Description: Add off-canvas sidebars using the Slidebars jQuery plugin
  * Plugin URI:  https://wordpress.org/plugins/off-canvas-sidebars/
- * Version:     0.3.1-dev
+ * Version:     0.3.1
  * Author:      Jory Hogeveen
  * Author URI:  http://www.keraweb.nl
  * Text Domain: off-canvas-sidebars
@@ -33,7 +33,7 @@
 
 ! defined( 'ABSPATH' ) and die( 'You shall not pass!' );
 
-define( 'OCS_PLUGIN_VERSION', '0.3.1-dev' );
+define( 'OCS_PLUGIN_VERSION', '0.3.1' );
 define( 'OCS_FILE', __FILE__ );
 define( 'OCS_BASENAME', plugin_basename( OCS_FILE ) );
 define( 'OCS_PLUGIN_DIR', plugin_dir_path( OCS_FILE ) );

--- a/off-canvas-sidebars.php
+++ b/off-canvas-sidebars.php
@@ -3,7 +3,7 @@
  * Plugin Name: Off-Canvas Sidebars
  * Description: Add off-canvas sidebars using the Slidebars jQuery plugin
  * Plugin URI:  https://wordpress.org/plugins/off-canvas-sidebars/
- * Version:     0.3
+ * Version:     0.3.1-dev
  * Author:      Jory Hogeveen
  * Author URI:  http://www.keraweb.nl
  * Text Domain: off-canvas-sidebars
@@ -33,14 +33,14 @@
 
 ! defined( 'ABSPATH' ) and die( 'You shall not pass!' );
 
-if ( !defined( 'OCS_PLUGIN_VERSION' ) ) define( 'OCS_PLUGIN_VERSION', '0.3' );
-if ( !defined( 'OCS_FILE' ) ) define( 'OCS_FILE', __FILE__ );
-if ( !defined( 'OCS_BASENAME' ) ) define( 'OCS_BASENAME', plugin_basename( __FILE__ ) );
-if ( !defined( 'OCS_PLUGIN_DIR' ) ) define( 'OCS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-if ( !defined( 'OCS_PLUGIN_URL' ) ) define( 'OCS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+define( 'OCS_PLUGIN_VERSION', '0.3.1-dev' );
+define( 'OCS_FILE', __FILE__ );
+define( 'OCS_BASENAME', plugin_basename( OCS_FILE ) );
+define( 'OCS_PLUGIN_DIR', plugin_dir_path( OCS_FILE ) );
+define( 'OCS_PLUGIN_URL', plugin_dir_url( OCS_FILE ) );
 
-final class OCS_Off_Canvas_Sidebars {
-
+final class OCS_Off_Canvas_Sidebars
+{
 	/**
 	 * The single instance of the class.
 	 *
@@ -285,10 +285,8 @@ final class OCS_Off_Canvas_Sidebars {
 	/**
 	 * Merge database plugin settings with default settings
 	 *
-	 * TODO: Make adding more sidebars dynamic (Slidebars will need to support more sidebars aswell)
-	 *
-	 * @return  array
 	 * @since   0.1
+	 * @return  array
 	 */
 	function get_settings() {
 		$settings = $this->general_settings;
@@ -306,10 +304,10 @@ final class OCS_Off_Canvas_Sidebars {
 	/**
 	 * Validate setting keys
 	 *
+	 * @since   0.2
 	 * @param   array  $settings
 	 * @param   array  $defaults
 	 * @return  array
-	 * @since   0.2
 	 */
 	function validate_settings( $settings, $defaults ) {
 		// supports one level array
@@ -329,48 +327,48 @@ final class OCS_Off_Canvas_Sidebars {
 	/**
 	 * Returns the default settings
 	 *
-	 * @return  string
 	 * @since   0.2
+	 * @return  string
 	 */
 	function get_default_settings() { return $this->default_settings; }
 
 	/**
 	 * Returns the default sidebar_settings
 	 *
-	 * @return  string
 	 * @since   0.2
+	 * @return  string
 	 */
 	function get_default_sidebar_settings() { return $this->default_sidebar_settings; }
 
 	/**
 	 * Returns the plugin version
 	 *
-	 * @return  string
 	 * @since   0.1.2
+	 * @return  string
 	 */
 	function get_version() { return $this->version; }
 
 	/**
 	 * Returns the plugin key
 	 *
-	 * @return  string
 	 * @since   0.1
+	 * @return  string
 	 */
 	function get_plugin_key() { return $this->plugin_key; }
 
 	/**
 	 * Returns the general key (plugin settings)
 	 *
-	 * @return  string
 	 * @since   0.1
+	 * @return  string
 	 */
 	function get_general_key() { return $this->general_key; }
 
 	/**
 	 * Returns the general labels
 	 *
-	 * @return  array
 	 * @since   0.1
+	 * @return  array
 	 */
 	function get_general_labels() {
 		return array(
@@ -382,9 +380,9 @@ final class OCS_Off_Canvas_Sidebars {
 	/**
 	 * Returns a sidebar key based on its label
 	 *
+	 * @since   0.1
 	 * @param   string  $label
 	 * @return  string  $key
-	 * @since   0.1
 	 */
 	function get_sidebar_key_by_label( $label ) {
 		foreach ( $this->general_settings['sidebars'] as $key => $value ) {
@@ -397,8 +395,8 @@ final class OCS_Off_Canvas_Sidebars {
 	/**
 	 * Checks if a sidebar is enabled
 	 *
-	 * @return  bool
 	 * @since   0.1
+	 * @return  bool
 	 */
 	function is_sidebar_enabled() {
 		foreach ( $this->general_settings['sidebars'] as $key => $value ) {
@@ -412,8 +410,8 @@ final class OCS_Off_Canvas_Sidebars {
 	 * Register slidebar sidebars
 	 * Also checks if theme is based on the Genesis Framework.
 	 *
-	 * @return  void
 	 * @since   0.1
+	 * @return  void
 	 */
 	function register_sidebars() {
 		foreach ( $this->general_settings['sidebars'] as $sidebar_id => $sidebar_data ) {
@@ -473,10 +471,10 @@ final class OCS_Off_Canvas_Sidebars {
 	/**
 	 * Add Settings link to plugin's entry on the Plugins page
 	 *
+	 * @since   0.1
 	 * @param   array   $links
 	 * @param   string  $file
 	 * @return  array
-	 * @since   0.1
 	 */
 	function add_settings_link( $links, $file ) {
 		static $this_plugin;

--- a/off-canvas-sidebars.php
+++ b/off-canvas-sidebars.php
@@ -192,9 +192,6 @@ final class OCS_Off_Canvas_Sidebars
 			// Load the OCS API
 			include_once 'includes/off-canvas-sidebars-api.class.php';
 
-			// Load translations
-			$this->load_textdomain();
-
 			$this->general_settings = ( get_option( $this->general_key ) ) ? get_option( $this->general_key ) : array();
 			$this->maybe_db_update();
 
@@ -229,6 +226,9 @@ final class OCS_Off_Canvas_Sidebars
 	function init() {
 		// Get the current user
 		//$this->curUser = wp_get_current_user();
+
+		// Load translations
+		$this->load_textdomain();
 
 		// Register the enabled sidebars
 		$this->register_sidebars();

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=YGPLM
 Tags: genesis, off-canvas, menus, widgets, sidebars, slidebars, jQuery, app, mobile, tablet, responsive
 Requires at least: 3.8
 Tested up to: 4.6
-Stable tag: 0.3
+Stable tag: 0.3.1
 
 Add off-canvas sidebars containing widgets, menus or other content using the Slidebars jQuery plugin.
 
@@ -100,6 +100,13 @@ The final output of your theme should be similar to this:
 8. Sidebar top (Push effect) -> image from Slidebars website
 
 == Changelog ==
+
+= 0.3.1 =
+*	Feature: Allow changing this plugin capability to show the settings page
+*	Fix: Update fixed element compat for the new Slidebars version (still experimental)
+*	Fix: Don't echo empty sidebar CSS selectors if no styles are set
+*	UI: Set `.ocs-button` to `cursor: pointer;` by default
+*	Update textdomain hook
 
 = 0.3 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -103,7 +103,7 @@ The final output of your theme should be similar to this:
 
 = 0.3.1 =
 *	Feature: Allow changing this plugin capability to show the settings page
-*	Fix: Update fixed element compat for the new Slidebars version (still experimental)
+*	Fix: Update fixed element compat for the new Slidebars version (still experimental, Slidebars still doesn't fully support fixed elements within the site container)
 *	Fix: Don't echo empty sidebar CSS selectors if no styles are set
 *	UI: Set `.ocs-button` to `cursor: pointer;` by default
 *	Update textdomain hook

--- a/widgets/off-canvas-sidebars-widget.php
+++ b/widgets/off-canvas-sidebars-widget.php
@@ -10,8 +10,8 @@
 
 ! defined( 'ABSPATH' ) and die( 'You shall not pass!' );
 
-final class OCS_Off_Canvas_Sidebars_Control_Widget extends WP_Widget {
-
+final class OCS_Off_Canvas_Sidebars_Control_Widget extends WP_Widget
+{
 	private $general_settings = array();
 	private $general_labels = array();
 	private $widget_setting = 'off-canvas-controls';


### PR DESCRIPTION
- [x] Feature: Allow changing this plugin capability to show the settings page
- [x] Fix: Update fixed element compat for the new Slidebars version (still experimental, Slidebars still doesn't fully support fixed elements within the site container)
- [x] Fix: Don't echo empty sidebar CSS selectors if no styles are set
- [x] UI: Set `.ocs-button` to `cursor: pointer;` by default
- [x] Enhancement: Update magic method error strings for translations
- [x] Update textdomain hook